### PR TITLE
Add Uni Kiel to supported universities

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -30,6 +30,7 @@ The App has been successfully tested on cards used at various universities:
 * HS Koblenz
 * Uni Koblenz
 * FH Köln
+* Uni Kiel (CAU-Card)
 * Uni Köln
 * Uni Leipzig
 * Uni Lüneburg


### PR DESCRIPTION
I tested it successfully. Probably only the new "CAU-Card" (student identity card) is supported, not the older "Campus Card" (Mifare Classic) that might still be in use by university staff.